### PR TITLE
Add copy user story with tasks action

### DIFF
--- a/app/coffee/modules/resources.coffee
+++ b/app/coffee/modules/resources.coffee
@@ -115,6 +115,7 @@ urls = {
     "userstory-downvote": "/userstories/%s/downvote"
     "userstory-watch": "/userstories/%s/watch"
     "userstory-unwatch": "/userstories/%s/unwatch"
+    "userstory-copy": "/userstories/%s/copy"
 
     # Tasks
     "tasks": "/tasks"

--- a/app/coffee/modules/resources/userstories.coffee
+++ b/app/coffee/modules/resources/userstories.coffee
@@ -89,6 +89,12 @@ resourceProvider = ($repo, $http, $urls, $storage, $q) ->
         url = $urls.resolve("userstory-unwatch", userStoryId)
         return $http.post(url)
 
+    service.copyWithTasks = (userStoryId, data={}) ->
+        url = $urls.resolve("userstory-copy", userStoryId)
+        payload = _.extend({include_tasks: true}, data)
+        return $http.post(url, payload).then (response) ->
+            return response.data
+
     service.bulkUpdateBacklogOrder = (projectId, milestoneId, afterUserstoryId, beforeUserstoryId, bulkUserstories) ->
         url = $urls.resolve("bulk-update-us-backlog-order")
         params = {project_id: projectId, bulk_userstories: bulkUserstories}

--- a/app/coffee/modules/userstories/detail.coffee
+++ b/app/coffee/modules/userstories/detail.coffee
@@ -265,6 +265,27 @@ class UserStoryDetailController extends mixOf(taiga.Controller, taiga.PageMixin)
 
         return @rs.userstories.unwatch(@scope.usId).then(onSuccess, onError)
 
+    copyUserStory: ->
+        data = {
+            include_tasks: true
+            keep_fields: ["subject", "description", "milestone"]
+        }
+
+        onSuccess = (newUserStory) =>
+            userStoryRef = newUserStory?.ref or newUserStory?.get?("ref")
+
+            if userStoryRef
+                ctx = {project: @scope.project.slug, ref: userStoryRef}
+                destination = @navUrls.resolve("project-userstories-detail", ctx)
+                @location.url(destination)
+
+            @confirm.success(@translate.instant("US.COPY_WITH_TASKS_SUCCESS"))
+
+        onError = =>
+            @confirm.notify("error")
+
+        return @rs.userstories.copyWithTasks(@scope.usId, data).then(onSuccess, onError)
+
     onTribeInfo: ->
         publishTitle = @translate.instant("US.TRIBE.PUBLISH_MORE_INFO_TITLE")
         image = $('<img />')

--- a/app/locales/taiga/locale-en.json
+++ b/app/locales/taiga/locale-en.json
@@ -1323,6 +1323,8 @@
         "SECTION_NAME": "User story",
         "LINK_TASKBOARD": "Taskboard",
         "TITLE_LINK_TASKBOARD": "Go to the taskboard",
+        "COPY_WITH_TASKS": "Copy with tasks",
+        "COPY_WITH_TASKS_SUCCESS": "User story duplicated with tasks",
         "TOTAL_POINTS": "total points",
         "ADD": "user story",
         "ADD_BULK": "Add some new user stories in bulk",

--- a/app/modules/resources/userstories-resource.service.coffee
+++ b/app/modules/resources/userstories-resource.service.coffee
@@ -59,6 +59,13 @@ Resource = (urlsService, http) ->
             .then (result) ->
                 return Immutable.fromJS(result.data)
 
+    service.copyWithTasks = (userStoryId, data={}) ->
+        url = urlsService.resolve("userstory-copy", userStoryId)
+        payload = _.extend({include_tasks: true}, data)
+        return http.post(url, payload)
+            .then (result) ->
+                return result.data
+
     return () ->
         return {"userstories": service}
 

--- a/app/partials/us/us-detail.jade
+++ b/app/partials/us/us-detail.jade
@@ -190,6 +190,17 @@ div.wrapper(
                 obj-type="us"
                 tg-check-permission="modify_us"
             )
+            button.ticket-copy-button.btn-small(
+                variant="secondary"
+                type="button"
+                ng-click="ctrl.copyUserStory()"
+                tg-check-permission="add_us"
+            )
+                tg-svg(
+                    svg-icon="icon-duplicate"
+                    svg-title-translate="US.COPY_WITH_TASKS"
+                )
+                span(translate="US.COPY_WITH_TASKS")
             tg-us-team-requirement-button(
                 ng-model="us"
                 tg-check-permission="modify_us"


### PR DESCRIPTION
## Summary
- add Taiga API mapping for copying user stories with tasks
- expose a copy-with-tasks action in the user story detail sidebar and wire it to the new resource method
- add localization for the new copy action feedback

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69307395fad8832ab95a0924c77eeb1a)